### PR TITLE
Implement padding for container and content widgets

### DIFF
--- a/Ngco/Alignment.cs
+++ b/Ngco/Alignment.cs
@@ -1,0 +1,11 @@
+﻿namespace Ngco {
+    public struct Alignment {
+        public VerticalAlignment VerticalAlignment { get; set; }
+        public HorizontalAlignment HorizontalAlignment { get; set; }
+
+        public Alignment(VerticalAlignment verticalAlignment, HorizontalAlignment horizontalAlignment) {
+            VerticalAlignment = verticalAlignment;
+            HorizontalAlignment = horizontalAlignment;
+        }
+    }
+}

--- a/Ngco/BaseWidget.cs
+++ b/Ngco/BaseWidget.cs
@@ -25,8 +25,9 @@ namespace Ngco {
 
 		public virtual bool IsFocusable => false;
 
-		public abstract void Render(RICanvas canvas);
-		public abstract Rect CalculateBoundingBox(Rect region);
+		public abstract void Render (RICanvas canvas);
+		public abstract void Measure(Size region);
+        public abstract void Layout (Rect region);
 
 		public string Id;
 		public BaseWidget Parent;
@@ -106,7 +107,15 @@ namespace Ngco {
 			return this;
 		}
 
-		public void UpdateStyles() {
+        public void SetPosition(Point position) {
+            BoundingBox = new Rect(position, BoundingBox.Size);
+        }
+
+        public void SetSize(Size size) {
+            BoundingBox = new Rect(BoundingBox.TopLeft, size);
+        }
+
+        public void UpdateStyles() {
 			if(!StylesDirty) return;
 			StylesDirty = false;
 			Style.Parents.Clear();
@@ -123,6 +132,14 @@ namespace Ngco {
 				child.UpdateStyles();
 			}
 		}
+
+        public void ApplyLayoutSize()
+        {
+            if (Style.Layout.Width != 0)
+                SetSize(new Size(Style.Layout.Width, BoundingBox.Size.Height));
+            if (Style.Layout.Height != 0)
+                SetSize(new Size(BoundingBox.Size.Width, Style.Layout.Height));
+        }
 
 		public virtual IEnumerator<BaseWidget> GetEnumerator() => Enumerable.Empty<BaseWidget>().GetEnumerator();
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/Ngco/Context.cs
+++ b/Ngco/Context.cs
@@ -36,8 +36,19 @@ namespace Ngco {
 			Widget?.UpdateAll(x => x.UpdateStyles());
 			Renderer.Render(canvas => {
 				canvas.Clear(Color.Win10Grey);
-				Widget?.CalculateBoundingBox(new Rect(0, 0, (int) Math.Ceiling(Renderer.Width / Renderer.Scale),
-					(int) Math.Ceiling(Renderer.Height / Renderer.Scale)));
+                Rect region = new Rect(0, 0, (int)Math.Ceiling(Renderer.Width / Renderer.Scale),
+                    (int)Math.Ceiling(Renderer.Height / Renderer.Scale));
+                var widget = Widget;
+                if (widget != null) {
+                    if (widget.Style.Layout.Width != 0)
+                        region.Size.Width = widget.Style.Layout.Width;
+                    if (widget.Style.Layout.Height != 0)
+                        region.Size.Height = widget.Style.Layout.Height;
+                }
+
+                Widget?.Measure(region.Size);
+                // stretch root element to fill renderer
+                Widget?.Layout(region);
 				Widget?.Render(canvas);
 			});
 		}

--- a/Ngco/HorizontalAlignment.cs
+++ b/Ngco/HorizontalAlignment.cs
@@ -1,0 +1,8 @@
+﻿namespace Ngco {
+    public enum HorizontalAlignment {
+        Left,
+        Center,
+        Right,
+        Stretch
+    }
+}

--- a/Ngco/Layout.cs
+++ b/Ngco/Layout.cs
@@ -1,0 +1,36 @@
+﻿namespace Ngco {
+    public class Layout {
+        private int _width;
+        private int _height;
+        private Margin _margin;
+        private Padding _padding;
+        private Alignment _alignment;
+        private Alignment _contentAlignment;
+        private int _spacing;
+
+        public int Width { get => _width; set => _width = value; }
+        public int Height { get => _height; set => _height = value; }
+        public int Spacing { get => _spacing; set => _spacing = value; }
+
+        public Margin Margin { get => _margin; set => _margin = value; }
+        public Padding Padding { get => _padding; set => _padding = value; }
+
+        public Alignment Alignment { get => _alignment; set => _alignment = value; }
+        public Alignment ContentAlignment { get => _contentAlignment; set => _contentAlignment = value; }
+
+        public Layout() {
+            Margin = new Margin(0);
+            Padding = new Padding(0);
+
+            Alignment = new Alignment() {
+                VerticalAlignment = VerticalAlignment.Up,
+                HorizontalAlignment = HorizontalAlignment.Left,
+            };
+
+            ContentAlignment = new Alignment() {
+                VerticalAlignment = VerticalAlignment.Center,
+                HorizontalAlignment = HorizontalAlignment.Left,
+            };
+        }
+    }
+}

--- a/Ngco/Loader.cs
+++ b/Ngco/Loader.cs
@@ -129,6 +129,9 @@ namespace Ngco {
 					case "multiline":
 						style.Multiline = ParseBool(value);
 						break;
+                    case "layout":
+                        style.Layout = ParseLayout(value);
+                        break;
 					case string x: throw new NotSupportedException($"Unknown style property {x}");
 				}
 			}
@@ -166,5 +169,74 @@ namespace Ngco {
 					return false;
 			}
 		}
+
+        Layout ParseLayout(string value) {
+            using (var input = new StringReader(value)) {
+                var yaml = new YamlStream();
+                yaml.Load(input);
+                // Examine the stream
+                var mapping = (YamlMappingNode)yaml.Documents[0].RootNode;
+                Layout layout = new Layout();
+                Alignment alignment;
+
+                foreach (var (nodekey, nodeVal) in mapping) {
+                    var body = ((YamlMappingNode)nodekey).Children;
+                    string key = body.Keys.ElementAt(0).ToString();
+                    value = body.Keys.ElementAt(1).ToString();
+                    switch (key.ToString()) {
+                        case "width":
+                            layout.Width = int.Parse(value);
+                            break;
+                        case "height":
+                            layout.Height = int.Parse(value);
+                            break;
+                        case "spacing":
+                            layout.Spacing = int.Parse(value);
+                            break;
+                        case "vertical-alignment":
+                            value = value.First().ToString().ToUpper() + value.Substring(1);
+                            alignment = layout.Alignment;
+                            alignment.VerticalAlignment = Enum.Parse<VerticalAlignment>(value);
+                            layout.Alignment = alignment;
+                            break;
+                        case "horizontal-alignment":
+                            value = value.First().ToString().ToUpper() + value.Substring(1);
+                            alignment = layout.Alignment;
+                            alignment.HorizontalAlignment = Enum.Parse<HorizontalAlignment>(value);
+                            layout.Alignment = alignment;
+                            break;
+                        case "margin":
+                            if (int.TryParse(value, out int margin))
+                                layout.Margin = new Margin(margin);
+                            else {
+                                string[] margins = value.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                                layout.Margin = new Margin() {
+                                    Up = int.Parse(margins[0]),
+                                    Right = int.Parse(margins[1]),
+                                    Down = int.Parse(margins[2]),
+                                    Left = int.Parse(margins[3]),
+                                };
+                            }
+                            break;
+                        case "padding":
+                            if (int.TryParse(value, out int padding)) {
+                                layout.Padding = new Padding(padding);
+                            }
+                            else {
+                                string[] paddings = value.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                                layout.Padding = new Padding() {
+                                    Up = int.Parse(paddings[0]),
+                                    Right = int.Parse(paddings[1]),
+                                    Down = int.Parse(paddings[2]),
+                                    Left = int.Parse(paddings[3]),
+                                };
+                            }
+                            break;
+                    }
+                }
+
+                return layout;
+            }
+        }
 	}
 }

--- a/Ngco/Margin.cs
+++ b/Ngco/Margin.cs
@@ -1,0 +1,27 @@
+﻿namespace Ngco {
+    public struct Margin {
+        private int _left;
+        private int _up;
+        private int _right;
+        private int _down;
+
+        public int Left { get => _left; set => _left = value; }
+        public int Up { get => _up; set => _up = value; }
+        public int Right { get => _right; set => _right = value; }
+        public int Down { get => _down; set => _down = value; }
+
+        public Margin(int margin) {
+            _left = margin;
+            _up = margin;
+            _right = margin;
+            _down = margin;
+        }
+
+        public Margin(int left, int up, int right, int down) {
+            _left = left;
+            _up = up;
+            _right = right;
+            _down = down;
+        }
+    }
+}

--- a/Ngco/Padding.cs
+++ b/Ngco/Padding.cs
@@ -1,0 +1,27 @@
+﻿namespace Ngco {
+    public struct Padding {
+        private int _left;
+        private int _up;
+        private int _right;
+        private int _down;
+
+        public int Left { get => _left; set => _left = value; }
+        public int Up { get => _up; set => _up = value; }
+        public int Right { get => _right; set => _right = value; }
+        public int Down { get => _down; set => _down = value; }
+
+        public Padding(int padding) {
+            _left = padding;
+            _up = padding;
+            _right = padding;
+            _down = padding;
+        }
+
+        public Padding(int left, int up, int right, int down) {
+            _left = left;
+            _up = up;
+            _right = right;
+            _down = down;
+        }
+    }
+}

--- a/Ngco/Style.cs
+++ b/Ngco/Style.cs
@@ -155,5 +155,21 @@ namespace Ngco {
 			get => _Multiline ?? (Context.Instance.BaseStyle.multiline ?? throw new NoNullAllowedException());
 			set => multiline = value;
 		}
-	}
+
+        Layout layout;
+        Layout _Layout {
+            get {
+                if (layout != null) return layout;
+                foreach (var style in Parents) {
+                    var val = style._Layout;
+                    if (val != null) return val;
+                }
+                return null;
+            }
+        }
+        public Layout Layout {
+            get => _Layout ?? (Context.Instance.BaseStyle.layout ?? throw new NoNullAllowedException());
+            set => layout = value;
+        }
+    }
 }

--- a/Ngco/VerticalAlignment.cs
+++ b/Ngco/VerticalAlignment.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ngco {
+    public enum VerticalAlignment {
+        Up,
+        Center,
+        Down,
+        Stretch
+    }
+}

--- a/Ngco/Widgets/Button.cs
+++ b/Ngco/Widgets/Button.cs
@@ -24,14 +24,59 @@ namespace Ngco.Widgets {
 		public override IEnumerator<BaseWidget> GetEnumerator() =>
 			new List<BaseWidget> { Label }.GetEnumerator();
 
-		public override Rect CalculateBoundingBox(Rect region) {
-			var labelBb = Label.CalculateBoundingBox(region.Inset(new Size(10, 10)));
-			var bb = new Rect(region.TopLeft, labelBb.Size + new Size(20, 20));
+        public override void Measure(Size region) {
+            Label.Measure(new Size(region.Width - (Style.Layout.Padding.Left + Style.Layout.Padding.Right),
+                region.Height - (Style.Layout.Padding.Up + Style.Layout.Padding.Down)));
+            BoundingBox = new Rect(new Point(0,0), new Size(Label.BoundingBox.Size.Width + Style.Layout.Padding.Left + Style.Layout.Padding.Right,
+                 Label.BoundingBox.Size.Height + Style.Layout.Padding.Up + Style.Layout.Padding.Down));
+            ApplyLayoutSize();
+        }
 
-			return BoundingBox = bb.ClipTo(region);
-		}
+        public override void Layout(Rect region) {
+            Point labelPosition = new Point();
+            switch (Label.Style.Layout.ContentAlignment.HorizontalAlignment) {
+                case HorizontalAlignment.Left:
+                    labelPosition.X += Style.Layout.Padding.Left;
+                    break;
+                case HorizontalAlignment.Center:
+                    int availableWidth = region.Size.Width - (Style.Layout.Padding.Left + Style.Layout.Padding.Right);
+                    int availableWidthMid = availableWidth / 2;
+                    int labelMidX = Label.BoundingBox.Size.Width / 2;
+                    // center label
+                    labelPosition.X += Style.Layout.Padding.Left + availableWidthMid - labelMidX;
+                    break;
+                case HorizontalAlignment.Right:
+                    labelPosition.X = region.Size.Width - Style.Layout.Padding.Right - Label.BoundingBox.Size.Width;
+                    break;
+            }
 
-		public override void Render(RICanvas canvas) {
+            switch (Label.Style.Layout.ContentAlignment.VerticalAlignment) {
+                case VerticalAlignment.Up:
+                    labelPosition.Y += Style.Layout.Padding.Up;
+                    break;
+                case VerticalAlignment.Center:
+                    int availableHeight = region.Size.Height - (Style.Layout.Padding.Up + Style.Layout.Padding.Down);
+                    int availableHeightMid = availableHeight / 2;
+                    int labelMidY = Label.BoundingBox.Size.Height / 2;
+
+                    // center label
+                    labelPosition.Y += Style.Layout.Padding.Up + availableHeightMid - labelMidY;
+
+                    break;
+                case VerticalAlignment.Down:
+                    labelPosition.Y = region.Size.Height - Style.Layout.Padding.Down - Label.BoundingBox.Size.Height;
+                    break;
+
+                case VerticalAlignment.Stretch:
+                    // ...
+                    break;
+            }
+            Label.SetPosition(region.TopLeft + labelPosition);
+            Label.BoundingBox.ClipTo(region);
+            Label.Layout(Label.BoundingBox);
+        }
+
+        public override void Render(RICanvas canvas) {
 			canvas.Save();
 			canvas.ClipRect(BoundingBox);
 
@@ -84,5 +129,5 @@ namespace Ngco.Widgets {
 			Clicked += callback;
 			return this;
 		}
-	}
+    }
 }

--- a/Ngco/Widgets/HBox.cs
+++ b/Ngco/Widgets/HBox.cs
@@ -1,25 +1,68 @@
+using System;
+
 namespace Ngco.Widgets {
 	public class HBox : BaseContainer {
 		public int Spacing  = 10;
 		public int HPadding = 10;
 		public int VPadding = 10;
 
-		public override Rect CalculateBoundingBox(Rect region) {
-			var bb = new Rect(region.TopLeft, new Size(HPadding, VPadding));
-			for(var i = 0; i < Children.Count; ++i) {
-				if(i != 0) bb.Size.Width += Spacing;
-				var widget = Children[i];
-				bb = bb.Extend(widget.CalculateBoundingBox(new Rect(
-					new Point(region.TopLeft.X + bb.Size.Width, region.TopLeft.Y + VPadding), 
-					Size.Infinite
-				).ClipTo(region)));
-			}
-			return BoundingBox = bb.ClipTo(region);
-		}
+        public override void Measure(Size region)
+        {
+            Size rowSize = new Size(region.Width, region.Height / Children.Count);
+            var bb = new Rect(new Point(), new Size());
+            Size contentSize = new Size();
 
-		public override void Render(RICanvas canvas) {
+            for (int i = 0; i < Children.Count; i++) {
+                var widget = Children[i];
+                widget.Measure(rowSize);
+                if (i == 0) {
+                    contentSize.Height = Math.Max(contentSize.Height, widget.BoundingBox.Size.Height);
+                    contentSize.Width = contentSize.Width + widget.BoundingBox.Size.Width;
+                }
+                else {
+                    contentSize.Height = Math.Max(contentSize.Height, widget.BoundingBox.Size.Height);
+                    contentSize.Width = contentSize.Width + widget.BoundingBox.Size.Width + Style.Layout.Spacing;
+                }
+            }
+
+            var paddedSize = new Size(contentSize.Width + Style.Layout.Padding.Left + Style.Layout.Padding.Right,
+               contentSize.Height + Style.Layout.Padding.Up + Style.Layout.Padding.Down);
+            BoundingBox = bb;
+            SetSize(paddedSize);
+            ApplyLayoutSize();
+        }
+
+        public override void Layout(Rect region)
+        {
+            Point currentWidgetPosition = region.TopLeft;
+            int columnHeight = region.Size.Height;
+
+            for (int i = 0; i < Children.Count; i++) {
+                var widget = Children[i];
+                Point widgetPosition = new Point();
+                if (i == 0) {
+                    currentWidgetPosition.X += Style.Layout.Padding.Left;
+                    currentWidgetPosition.Y += Style.Layout.Padding.Up;
+                }
+                int paddingOffset = -Style.Layout.Padding.Down;
+                int midY = widgetPosition.Y + (int)Math.Ceiling((float)columnHeight / 2);
+                // reposition widget
+                int widgetMidY = (int)Math.Ceiling((float)widget.BoundingBox.Size.Height / 2);
+                widgetPosition.Y = midY - widgetMidY;
+                // Apply offset
+                widgetPosition.Y += paddingOffset;
+                widgetPosition = widgetPosition + currentWidgetPosition;
+                currentWidgetPosition.X += widget.BoundingBox.Size.Width + Style.Layout.Spacing;
+                // update position
+                widget.SetPosition(widgetPosition);
+                widget.BoundingBox.ClipTo(region);
+                widget.Layout(widget.BoundingBox);
+            }
+        }
+
+        public override void Render(RICanvas canvas) {
 			foreach(var widget in this)
 				widget.Render(canvas);
 		}
-	}
+    }
 }

--- a/Ngco/Widgets/Image.cs
+++ b/Ngco/Widgets/Image.cs
@@ -27,11 +27,6 @@ namespace Ngco.Widgets {
 					ImageLoaded = SKBitmap.Decode(stream);
 		}
 
-		public override Rect CalculateBoundingBox(Rect region) {
-			var bb = _Path != "" && File.Exists(_Path) ? new Rect(region.TopLeft, new Size(ImageLoaded.Width, ImageLoaded.Height)) : new Rect();
-			return BoundingBox = bb.ClipTo(region);
-		}
-
 		public override void Render(RICanvas canvas) {
 			if (_Path != "" && File.Exists(_Path)) {
 				canvas.Save();
@@ -40,5 +35,13 @@ namespace Ngco.Widgets {
 				canvas.Restore();
 			}
 		}
-	}
+
+        public override void Measure(Size region)
+        {
+            BoundingBox = _Path != "" && File.Exists(_Path) ? new Rect(new Point(), new Size(ImageLoaded.Width, ImageLoaded.Height)) : new Rect();
+            ApplyLayoutSize();
+        }
+
+        public override void Layout(Rect region) { }
+    }
 }

--- a/Ngco/Widgets/Label.cs
+++ b/Ngco/Widgets/Label.cs
@@ -16,18 +16,22 @@ namespace Ngco.Widgets {
 		public Label(string text = "Label") =>
 			Text = text;
 
-		public override Rect CalculateBoundingBox(Rect region) {
-			var lines = Style.Multiline ? Text.Split("\\n") : new string[] { Text };
-			var bb = new Rect(region.TopLeft, new Size((int) Math.Ceiling(Paint.MeasureText(lines.OrderByDescending(s => s.Length).First())), Style.TextSize * lines.Length));
-			return BoundingBox = bb.ClipTo(region);
-		}
+        public override void Measure(Size region)
+        {
+            var lines = Style.Multiline ? Text.Split("\\n") : new string[] { Text };
+            BoundingBox = new Rect(new Point(), new Size((int)Math.Ceiling(Paint.MeasureText(lines.OrderByDescending(s => s.Length).First())),
+                Style.TextSize * lines.Length));
+            ApplyLayoutSize();
+        }
 
-		public override void Render(RICanvas canvas) {
+        public override void Render(RICanvas canvas) {
 			var paint = Paint;
 			canvas.Save();
 			canvas.ClipRect(BoundingBox.Inset(BoundingBox.Size * -0.1f));
 			canvas.DrawText(Text, BoundingBox.TopLeft.X, BoundingBox.TopLeft.Y - (paint.FontSpacing - Style.TextSize) + Style.TextSize, paint, Style.Multiline);
 			canvas.Restore();
 		}
-	}
+
+        public override void Layout(Rect region){ }
+    }
 }

--- a/Ngco/Widgets/TextBox.cs
+++ b/Ngco/Widgets/TextBox.cs
@@ -24,13 +24,6 @@ namespace Ngco.Widgets {
 		public override IEnumerator<BaseWidget> GetEnumerator() =>
 			new List<BaseWidget> { Label }.GetEnumerator();
 
-		public override Rect CalculateBoundingBox(Rect region) {
-			var labelBb = Label.CalculateBoundingBox(region.Inset(new Size(10, 10)));
-			var bb = new Rect(region.TopLeft, labelBb.Size + new Size(20, 20));
-
-			return BoundingBox = bb.ClipTo(region);
-		}
-
 		public override void Render(RICanvas canvas) {
 			canvas.Save();
 			canvas.ClipRect(BoundingBox);
@@ -95,5 +88,24 @@ namespace Ngco.Widgets {
 			Clicked += callback;
 			return this;
 		}
-	}
+
+        public override void Measure(Size region)
+        {
+            Label.Measure(new Size(region.Width - (Style.Layout.Padding.Left + Style.Layout.Padding.Right),
+                region.Height - (Style.Layout.Padding.Up + Style.Layout.Padding.Down)));
+            BoundingBox = new Rect(new Point(0, 0), new Size(Label.BoundingBox.Size.Width + Style.Layout.Padding.Left + Style.Layout.Padding.Right,
+                 Label.BoundingBox.Size.Height + Style.Layout.Padding.Up + Style.Layout.Padding.Down));
+            ApplyLayoutSize();
+        }
+
+        public override void Layout(Rect region)
+        {
+            Point labelPosition = new Point();
+            labelPosition.X += Style.Layout.Padding.Left;
+            labelPosition.Y += Style.Layout.Padding.Up;
+            Label.SetPosition(region.TopLeft + labelPosition);
+            Label.BoundingBox.ClipTo(region);
+            Label.Layout(Label.BoundingBox);
+        }
+    }
 }

--- a/Ngco/Widgets/VBox.cs
+++ b/Ngco/Widgets/VBox.cs
@@ -1,24 +1,64 @@
-namespace Ngco.Widgets {
-	public class VBox : BaseContainer {
+using SkiaSharp;
+using System;
+
+namespace Ngco.Widgets
+{
+    public class VBox : BaseContainer {
 		public int Spacing  = 10;
 		public int HPadding = 10;
 		public int VPadding = 10;
 
-		public override Rect CalculateBoundingBox(Rect region) {
-			var bb = new Rect(region.TopLeft, new Size(HPadding, VPadding));
-			for(var i = 0; i < Children.Count; ++i) {
-				if(i != 0) bb.Size.Height += Spacing;
-				var widget = Children[i];
-				bb = bb.Extend(widget.CalculateBoundingBox(new Rect(
-					new Point(region.TopLeft.X + HPadding, region.TopLeft.Y + bb.Size.Height), 
-					Size.Infinite
-				).ClipTo(region)));
-			}
-			return BoundingBox = bb.ClipTo(region);
-		}
+        public override void Measure(Size region) {
+            Size rowSize = new Size(region.Width, region.Height / Children.Count);
+            var bb = new Rect(new Point(), new Size());
+            Size contentSize = new Size();
+            for(int i = 0; i< Children.Count; i++) {
+                var widget = Children[i];
+                widget.Measure(rowSize);
+                if(i == 0) {
+                    contentSize.Width = Math.Max(contentSize.Width, widget.BoundingBox.Size.Width);
+                    contentSize.Height = contentSize.Height + widget.BoundingBox.Size.Height;
+                }
+                else {
+                    contentSize.Width = Math.Max(contentSize.Width, widget.BoundingBox.Size.Width);
+                    contentSize.Height = contentSize.Height + widget.BoundingBox.Size.Height + Style.Layout.Spacing;
+                }
+            }
+            var paddedSize = new Size(contentSize.Width + Style.Layout.Padding.Left + Style.Layout.Padding.Right,
+               contentSize.Height + Style.Layout.Padding.Up + Style.Layout.Padding.Down);
+            BoundingBox = bb;
+            SetSize(paddedSize);
+            ApplyLayoutSize();
+        }
 
-		public override void Render(RICanvas canvas) {
-			foreach(var widget in this)
+        public override void Layout(Rect region) {
+            Point currentWidgetPosition = region.TopLeft;
+            int rowWidth = region.Size.Width;
+            for (int i = 0; i < Children.Count; i++) {
+                var widget = Children[i];
+                Point widgetPosition = new Point();
+                if (i == 0) {
+                    currentWidgetPosition.X += Style.Layout.Padding.Left;
+                    currentWidgetPosition.Y += Style.Layout.Padding.Up;
+                }
+                int paddingOffset = -Style.Layout.Padding.Right;
+                int midX = widgetPosition.X + (int)Math.Ceiling((float)rowWidth / 2);
+                // reposition widget
+                int widgetMidX = (int)Math.Ceiling((float)widget.BoundingBox.Size.Width / 2);
+                widgetPosition.X = midX - widgetMidX;
+                // Apply offset
+                widgetPosition.X += paddingOffset;
+                widgetPosition = widgetPosition + currentWidgetPosition;
+                currentWidgetPosition.Y += widget.BoundingBox.Size.Height + Style.Layout.Spacing;
+                // update position
+                widget.SetPosition(widgetPosition);
+                widget.BoundingBox.ClipTo(region);
+                widget.Layout(widget.BoundingBox);
+            }
+        }
+
+        public override void Render(RICanvas canvas) {
+            foreach (var widget in this)
 				widget.Render(canvas);
 		}
 	}

--- a/TestApp/layout.yml
+++ b/TestApp/layout.yml
@@ -43,6 +43,8 @@ styles:
       outline-color: blue
       focusable: true
       text-color: black
+      layout:
+        width: 400
   - "textbox :focused":
       outline-color: red
 

--- a/TestApp/layout.yml
+++ b/TestApp/layout.yml
@@ -10,6 +10,14 @@ styles:
       enabled: true
       multiline: false
       corner-radius: 0
+      layout: 
+        width: 0
+        height: 0
+        vertical-alignment: stretch
+        horizontal-alignment: stretch
+        margin: 5
+        padding: 5
+        spacing: 5
   - hbox > .testing:
       text-color: green
       text-size: 75


### PR DESCRIPTION
This implements padding for containers( vbox, hbox) and content widgets(eg. buttons). It also add automatic and absolute dimensions for widgets.
Setting widgets dimensions to 0, which is the default, allows it to use as mush space as it needs to layout its children, with padding taken into consideration.
Also, for content widgets,  content alignment is used to position content with themselves.

Currently margins are not used by any widget. I am reserving them for layout widgets/elements, like grids, stacks etc.