### PR TITLE
Limit Framerate to 30fps

### DIFF
--- a/Ngco.Standalone/AppWindow.cs
+++ b/Ngco.Standalone/AppWindow.cs
@@ -17,8 +17,7 @@ namespace Ngco.Standalone {
 			GameWindowFlags.Default, DisplayDevice.Default, 4, 1, GraphicsContextFlags.ForwardCompatible
 		) => Context = new Context(new Renderer { Scale = 1 });
 
-        public void MainLoop()
-        {
+        public void MainLoop() {
             Visible = true;
             VSync   = VSyncMode.Off;
             Context.Renderer.Width  = Width;
@@ -34,8 +33,7 @@ namespace Ngco.Standalone {
             RendererThread.Join();
         }
 
-        public void RenderLoop()
-        {
+        public void RenderLoop() {
             MakeCurrent();
             Stopwatch timer = new Stopwatch();
             timer.Start();

--- a/Ngco.Standalone/AppWindow.cs
+++ b/Ngco.Standalone/AppWindow.cs
@@ -3,22 +3,60 @@ using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Input;
 using System;
+using System.Threading;
+using System.Diagnostics;
 
 namespace Ngco.Standalone {
 	public class AppWindow : GameWindow {
 		public readonly new Context Context;
+
+        private Thread RendererThread;
 
 		public AppWindow() : base(
 			1280, 720, new GraphicsMode(32, 24, 8, 0), "Ngco.Standalone",
 			GameWindowFlags.Default, DisplayDevice.Default, 4, 1, GraphicsContextFlags.ForwardCompatible
 		) => Context = new Context(new Renderer { Scale = 1 });
 
-		protected override void OnRenderFrame(FrameEventArgs e) {
-			Context.Renderer.Width  = Width;
-			Context.Renderer.Height = Height;
-			Context.Render();
-			SwapBuffers();
-		}
+        public void MainLoop()
+        {
+            Visible = true;
+            VSync   = VSyncMode.Off;
+            Context.Renderer.Width  = Width;
+            Context.Renderer.Height = Height;
+            Context.InvalidateLayout();
+            base.Context.MakeCurrent(null);
+            RendererThread = new Thread(RenderLoop);
+            RendererThread.Start();
+            while (Exists && !IsExiting) {
+                ProcessEvents();
+                Thread.Sleep(16);
+            }
+            RendererThread.Join();
+        }
+
+        public void RenderLoop()
+        {
+            MakeCurrent();
+            Stopwatch timer = new Stopwatch();
+            timer.Start();
+            float ticksPerFrame = (float)Stopwatch.Frequency / 30;
+            float msPerFrame = 1000f / 30;
+            long ticks = 0;
+            while (Exists && !IsExiting) {
+                Render();
+                ticks = timer.ElapsedTicks;                
+                float msElapsed = (float)ticks * 1000 / Stopwatch.Frequency;
+                Thread.Sleep((int)MathF.Max(1f, msPerFrame - msElapsed));
+                timer.Restart();
+            }
+        }
+
+        public void Render() {
+            Context.Renderer.Width = Width;
+            Context.Renderer.Height = Height;
+            Context.Render();
+            SwapBuffers();
+        }
 
 		protected override void OnMouseMove(MouseMoveEventArgs e) =>
 			Context.MouseMove(new Point((int) Math.Round(e.X / Context.Renderer.Scale), (int) Math.Round(e.Y / Context.Renderer.Scale)));
@@ -36,7 +74,19 @@ namespace Ngco.Standalone {
 			}
 		}
 
-		protected override void OnMouseDown(MouseButtonEventArgs e) =>
+        protected override void OnResize(EventArgs e) {
+            base.OnResize(e);
+            Context.InvalidateLayout();
+        }
+
+        protected override void OnLoad(EventArgs e) {
+            base.OnLoad(e);
+            Context.Renderer.Width  = Width;
+            Context.Renderer.Height = Height;
+            Context.InvalidateLayout();
+        }
+
+        protected override void OnMouseDown(MouseButtonEventArgs e) =>
 			Context.MouseDown(FromOpenTK(e.Button));
 
 		protected override void OnMouseUp(MouseButtonEventArgs e) =>

--- a/Ngco/BaseWidget.cs
+++ b/Ngco/BaseWidget.cs
@@ -133,8 +133,7 @@ namespace Ngco {
 			}
 		}
 
-        public void ApplyLayoutSize()
-        {
+        public void ApplyLayoutSize() {
             if (Style.Layout.Width != 0)
                 SetSize(new Size(Style.Layout.Width, BoundingBox.Size.Height));
             if (Style.Layout.Height != 0)

--- a/Ngco/Context.cs
+++ b/Ngco/Context.cs
@@ -33,11 +33,20 @@ namespace Ngco {
 		}
 
 		public void Render() {
-			Widget?.UpdateAll(x => x.UpdateStyles());
-			Renderer.Render(canvas => {
-				canvas.Clear(Color.Win10Grey);
+            lock (this) {
+                Renderer.Render(canvas => {
+                    Widget?.UpdateAll(x => x.UpdateStyles());
+                    canvas.Clear(Color.Win10Grey);
+                    Widget?.Render(canvas);
+                });
+            }
+		}
+
+        public void InvalidateLayout() {
+            lock (this) {
+                Widget?.UpdateAll(x => x.UpdateStyles());
                 Rect region = new Rect(0, 0, (int)Math.Ceiling(Renderer.Width / Renderer.Scale),
-                    (int)Math.Ceiling(Renderer.Height / Renderer.Scale));
+                   (int)Math.Ceiling(Renderer.Height / Renderer.Scale));
                 var widget = Widget;
                 if (widget != null) {
                     if (widget.Style.Layout.Width != 0)
@@ -49,9 +58,8 @@ namespace Ngco {
                 Widget?.Measure(region.Size);
                 // stretch root element to fill renderer
                 Widget?.Layout(region);
-				Widget?.Render(canvas);
-			});
-		}
+            }
+        }
 
 		bool CallAll(BaseWidget inner, Func<BaseWidget, bool> func) {
 			var clist = new List<BaseWidget>();

--- a/Ngco/Widgets/HBox.cs
+++ b/Ngco/Widgets/HBox.cs
@@ -6,8 +6,7 @@ namespace Ngco.Widgets {
 		public int HPadding = 10;
 		public int VPadding = 10;
 
-        public override void Measure(Size region)
-        {
+        public override void Measure(Size region) {
             Size rowSize = new Size(region.Width, region.Height / Children.Count);
             var bb = new Rect(new Point(), new Size());
             Size contentSize = new Size();
@@ -32,8 +31,7 @@ namespace Ngco.Widgets {
             ApplyLayoutSize();
         }
 
-        public override void Layout(Rect region)
-        {
+        public override void Layout(Rect region) {
             Point currentWidgetPosition = region.TopLeft;
             int columnHeight = region.Size.Height;
 

--- a/Ngco/Widgets/Image.cs
+++ b/Ngco/Widgets/Image.cs
@@ -36,8 +36,7 @@ namespace Ngco.Widgets {
 			}
 		}
 
-        public override void Measure(Size region)
-        {
+        public override void Measure(Size region) {
             BoundingBox = _Path != "" && File.Exists(_Path) ? new Rect(new Point(), new Size(ImageLoaded.Width, ImageLoaded.Height)) : new Rect();
             ApplyLayoutSize();
         }

--- a/Ngco/Widgets/Label.cs
+++ b/Ngco/Widgets/Label.cs
@@ -16,8 +16,7 @@ namespace Ngco.Widgets {
 		public Label(string text = "Label") =>
 			Text = text;
 
-        public override void Measure(Size region)
-        {
+        public override void Measure(Size region) {
             var lines = Style.Multiline ? Text.Split("\\n") : new string[] { Text };
             BoundingBox = new Rect(new Point(), new Size((int)Math.Ceiling(Paint.MeasureText(lines.OrderByDescending(s => s.Length).First())),
                 Style.TextSize * lines.Length));

--- a/Ngco/Widgets/TextBox.cs
+++ b/Ngco/Widgets/TextBox.cs
@@ -89,8 +89,7 @@ namespace Ngco.Widgets {
 			return this;
 		}
 
-        public override void Measure(Size region)
-        {
+        public override void Measure(Size region) {
             Label.Measure(new Size(region.Width - (Style.Layout.Padding.Left + Style.Layout.Padding.Right),
                 region.Height - (Style.Layout.Padding.Up + Style.Layout.Padding.Down)));
             BoundingBox = new Rect(new Point(0, 0), new Size(Label.BoundingBox.Size.Width + Style.Layout.Padding.Left + Style.Layout.Padding.Right,
@@ -98,8 +97,7 @@ namespace Ngco.Widgets {
             ApplyLayoutSize();
         }
 
-        public override void Layout(Rect region)
-        {
+        public override void Layout(Rect region) {
             Point labelPosition = new Point();
             labelPosition.X += Style.Layout.Padding.Left;
             labelPosition.Y += Style.Layout.Padding.Up;

--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -8,7 +8,7 @@ using PrettyPrinter;
 
 namespace TestApp {
 	class Program : AppWindow {
-		static void Main() => new Program().Run();
+        static void Main() => new Program().MainLoop();
 
 		Program() {
 			Title = "TestApp";
@@ -26,6 +26,8 @@ namespace TestApp {
 			Context.Find("#button-b").Click(_ => "B".Print());
 
 			Context.Find("hbox > button").Skip(1).Take(1).AddClass("testing");
+
+            Context.InvalidateLayout();
 		}
 	}
 }


### PR DESCRIPTION
Currently, the app uses too much gpu/cpu to do pretty much nothing. it is allowed to run as fast as it can, which is not necessary. This pr limits the update and frame rate to 30 hz, cutting down gpu usage on my pc  from 55% to 13%. It would be best is we could split the updating of states and the rendering, and only trigger updates when necessary.