### PR TITLE
Add support for custom properties

### DIFF
--- a/Ngco/BaseWidget.cs
+++ b/Ngco/BaseWidget.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using YamlDotNet.RepresentationModel;
 
 namespace Ngco
 {
@@ -16,6 +17,9 @@ namespace Ngco
         public abstract void Render(RICanvas canvas);
         public abstract void Measure(Size region);
         public abstract void Layout(Rect region);
+
+        public virtual void Load(YamlNode propertiesNode) { }
+        public virtual void Load(string   properties)     { }
 
         public string     Id;
         public BaseWidget Parent;

--- a/Ngco/BaseWidget.cs
+++ b/Ngco/BaseWidget.cs
@@ -26,14 +26,44 @@ namespace Ngco
 
         public Rect BoundingBox { get; protected set; }
 
-        public bool Focusable => IsFocusable && Style.Focusable;
+        /// <summary>
+        /// Enabled
+        /// </summary>
+
+        private bool enabled = true;
+
+        bool _Enabled
+        {
+            get
+            {
+                return enabled && Parent._Enabled;
+            }
+        }
+
+        public bool Enabled
+        {
+            get => _Enabled;
+            set => enabled = value;
+        }
+
+        /// <summary>
+        /// Focusable
+        /// </summary>
+
+        private bool _Focusable;
+
+        public bool Focusable
+        {
+            get => _Focusable && IsFocusable;
+            set => _Focusable = value && IsFocusable;
+        }
 
         public bool Focused
         {
             get => this == Context.Instance.Focused;
             set
             {
-                if (!Style.Focusable) return;
+                if (!Focusable) return;
                 if (value) Context.Instance.Focused = this;
                 else if (Focused) Context.Instance.Focused = null;
             }

--- a/Ngco/BaseWidget.cs
+++ b/Ngco/BaseWidget.cs
@@ -15,8 +15,8 @@ namespace Ngco
         public virtual bool IsFocusable => false;
 
         public abstract void Render(RICanvas canvas);
-        public abstract void Measure(Size region);
-        public abstract void Layout(Rect region);
+        public abstract void OnMeasure(Size region);
+        public abstract void OnLayout(Rect region);
 
         public virtual void Load(YamlNode propertiesNode) { }
         public virtual void Load(string   properties)     { }
@@ -67,6 +67,14 @@ namespace Ngco
                 if (value) Context.Instance.Focused = this;
                 else if (Focused) Context.Instance.Focused = null;
             }
+        }
+
+        private Layout _layout;
+
+        public Layout Layout
+        {
+            get => _layout?? Layout.Default;
+            set => _layout = value;
         }
 
         internal bool StylesDirty = true;
@@ -209,8 +217,8 @@ namespace Ngco
 
         public void ApplyLayoutSize()
         {
-            if (Style.Layout.Width != 0)  SetSize(new Size(Style.Layout.Width, BoundingBox.Size.Height));
-            if (Style.Layout.Height != 0) SetSize(new Size(BoundingBox.Size.Width, Style.Layout.Height));
+            if (Layout.Width != 0)  SetSize(new Size(Layout.Width, BoundingBox.Size.Height));
+            if (Layout.Height != 0) SetSize(new Size(BoundingBox.Size.Width, Layout.Height));
         }
 
         public virtual IEnumerator<BaseWidget> GetEnumerator() => Enumerable.Empty<BaseWidget>().GetEnumerator();

--- a/Ngco/BaseWidget.cs
+++ b/Ngco/BaseWidget.cs
@@ -12,14 +12,15 @@ namespace Ngco
         public readonly List<string> Classes = new List<string>();
         public readonly Style Style = new Style();
 
+        public virtual string[] PropertyKeys { get; } = new string[0];
+
         public virtual bool IsFocusable => false;
 
         public abstract void Render(RICanvas canvas);
         public abstract void OnMeasure(Size region);
         public abstract void OnLayout(Rect region);
 
-        public virtual void Load(YamlNode propertiesNode) { }
-        public virtual void Load(string   properties)     { }
+        public virtual void Load(Dictionary<string,string> properties) { }
 
         public string     Id;
         public BaseWidget Parent;

--- a/Ngco/Context.cs
+++ b/Ngco/Context.cs
@@ -66,14 +66,14 @@ namespace Ngco
 
                 if (widget != null)
                 {
-                    if (widget.Style.Layout.Width != 0)  region.Size.Width = widget.Style.Layout.Width;
-                    if (widget.Style.Layout.Height != 0) region.Size.Height = widget.Style.Layout.Height;
+                    if (widget.Layout.Width != 0)  region.Size.Width = widget.Layout.Width;
+                    if (widget.Layout.Height != 0) region.Size.Height = widget.Layout.Height;
                 }
 
-                Widget?.Measure(region.Size);
+                Widget?.OnMeasure(region.Size);
 
                 // Stretch root element to fill renderer
-                Widget?.Layout(region);
+                Widget?.OnLayout(region);
             }
         }
 

--- a/Ngco/Helpers.cs
+++ b/Ngco/Helpers.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Ngco
 {
-    public static class Parsers
+    public static class Helpers
     {
         public static bool ParseBool(string value)
         {

--- a/Ngco/Layout.cs
+++ b/Ngco/Layout.cs
@@ -2,6 +2,27 @@
 {
     public class Layout
     {
+        public static Layout Default = new Layout()
+        {
+            Width   = 0,
+            Height  = 0,
+            Spacing = 5,
+            Margin  = new Margin(5),
+            Padding = new Padding(5),
+
+            Alignment = new Alignment()
+            {
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+            },
+
+            ContentAlignment = new Alignment()
+            {
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+            },
+        };
+
         public int Width   { get; set; }
         public int Height  { get; set; }
         public int Spacing { get; set; }

--- a/Ngco/Layout.cs
+++ b/Ngco/Layout.cs
@@ -13,13 +13,13 @@
             Alignment = new Alignment()
             {
                 HorizontalAlignment = HorizontalAlignment.Center,
-                VerticalAlignment = VerticalAlignment.Center,
+                VerticalAlignment   = VerticalAlignment.Center,
             },
 
             ContentAlignment = new Alignment()
             {
                 HorizontalAlignment = HorizontalAlignment.Center,
-                VerticalAlignment = VerticalAlignment.Center,
+                VerticalAlignment   = VerticalAlignment.Center,
             },
         };
 

--- a/Ngco/Loader.cs
+++ b/Ngco/Loader.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Linq;
 using YamlDotNet.RepresentationModel;
 
-using static Ngco.Parsers;
+using static Ngco.Helpers;
 
 namespace Ngco
 {
@@ -73,7 +73,26 @@ namespace Ngco
                 default: throw new NotSupportedException($"Unknown widget class: {cls}");
             }
 
-            widget.Load(body);
+            var subNode = (YamlSequenceNode)body;
+
+            Dictionary<string, string> properties = new Dictionary<string, string>();
+
+            for (int index = 0; index < subNode.Children.Count; index++)
+            {
+                var sub                  = subNode.Children[index];
+                var (keyNode, valueNode) = ((YamlMappingNode)sub).Children.First();
+                string key               = keyNode.ToString().ToLower();
+                string value             = valueNode.ToString();
+
+                if (widget.PropertyKeys.Contains(key))
+                {
+                    properties.Add(key, value);
+
+                    subNode.Children.Remove(sub);
+                }
+            }
+
+            widget.Load(properties);
 
             foreach (YamlNode sub in (YamlSequenceNode)body)
             {

--- a/Ngco/Loader.cs
+++ b/Ngco/Loader.cs
@@ -6,6 +6,8 @@ using System.IO;
 using System.Linq;
 using YamlDotNet.RepresentationModel;
 
+using static Ngco.Parsers;
+
 namespace Ngco
 {
     public class Loader
@@ -101,7 +103,15 @@ namespace Ngco
                             case "class":
                                 widget.AddClass(value);
                                 break;
-
+                            case "enabled":
+                                widget.Enabled = ParseBool(value);
+                                break;
+                            case "focusable":
+                                if (widget.IsFocusable)
+                                    widget.Focusable = ParseBool(value);
+                                else
+                                    throw new NotSupportedException($"{key} is not valid for this widget");
+                                break;
                             default: throw new NotSupportedException($"Unknown property for widget: {key}");
                         }
                     }
@@ -129,9 +139,6 @@ namespace Ngco
                     case "text-size":        style.TextSize        = int.Parse(value);   break;
                     case "font-family":      style.FontFamily      = value;              break;
                     case "corner-radius":    style.CornerRadius    = int.Parse(value);   break;
-                    case "focusable":        style.Focusable       = ParseBool(value);   break;
-                    case "enabled":          style.Enabled         = ParseBool(value);   break;
-                    case "multiline":        style.Multiline       = ParseBool(value);   break;
                     case "layout":           style.Layout          = ParseLayout(value); break;
 
                     case string x: throw new NotSupportedException($"Unknown style property {x}");
@@ -167,17 +174,6 @@ namespace Ngco
                     return new Color(rgb[0], rgb[1], rgb[2]);
 
                 default: throw new NotSupportedException($"Unknown color {value}");
-            }
-        }
-
-        bool ParseBool(string value)
-        {
-            switch (value.ToLower())
-            {
-                case "true":
-                case "1": return true;
-
-                default: return false;
             }
         }
 

--- a/Ngco/Loader.cs
+++ b/Ngco/Loader.cs
@@ -112,6 +112,9 @@ namespace Ngco
                                 else
                                     throw new NotSupportedException($"{key} is not valid for this widget");
                                 break;
+                            case "layout":
+                                widget.Layout = ParseLayout(value);
+                                break;
                             default: throw new NotSupportedException($"Unknown property for widget: {key}");
                         }
                     }
@@ -139,7 +142,6 @@ namespace Ngco
                     case "text-size":        style.TextSize        = int.Parse(value);   break;
                     case "font-family":      style.FontFamily      = value;              break;
                     case "corner-radius":    style.CornerRadius    = int.Parse(value);   break;
-                    case "layout":           style.Layout          = ParseLayout(value); break;
 
                     case string x: throw new NotSupportedException($"Unknown style property {x}");
                 }

--- a/Ngco/Parsers.cs
+++ b/Ngco/Parsers.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ngco
+{
+    public static class Parsers
+    {
+        public static bool ParseBool(string value)
+        {
+            switch (value.ToLower())
+            {
+                case "true":
+                case "1": return true;
+
+                default: return false;
+            }
+        }
+    }
+}

--- a/Ngco/RICanvas.cs
+++ b/Ngco/RICanvas.cs
@@ -59,7 +59,7 @@ namespace Ngco
 
         public void DrawText(string text, float x, float y, SKPaint paint, bool multiline)
         {
-            string[] lines = multiline ? text.Split("\\n") : new string[] { text };
+            string[] lines = multiline ? text.Split("\n") : new string[] { text };
 
             for (int i = 0; i < lines.Length; i++)
             {

--- a/Ngco/Style.cs
+++ b/Ngco/Style.cs
@@ -185,33 +185,6 @@ namespace Ngco
             set => cornerRadius = value;
         }
 
-        /// <summary>
-        /// Layout
-        /// </summary>
-
-        Layout layout;
-
-        Layout _Layout
-        {
-            get
-            {
-                if (layout != null) return layout;
-
-                foreach (Style style in Parents)
-                {
-                    Layout val = style._Layout;
-
-                    if (val != null) return val;
-                }
-
-                return null;
-            }
-        }
-
-        public Layout Layout
-        {
-            get => _Layout ?? (Context.Instance.BaseStyle.layout ?? throw new NoNullAllowedException());
-            set => layout = value;
-        }
+        
     }
 }

--- a/Ngco/Style.cs
+++ b/Ngco/Style.cs
@@ -157,64 +157,6 @@ namespace Ngco
         }
 
         /// <summary>
-        /// Focusable
-        /// </summary>
-
-        bool? focusable;
-
-        bool? _Focusable
-        {
-            get
-            {
-                if (focusable != null) return focusable;
-
-                foreach (Style style in Parents)
-                {
-                    bool? val = style._Focusable;
-
-                    if (val != null) return val;
-                }
-
-                return null;
-            }
-        }
-
-        public bool Focusable
-        {
-            get => _Focusable ?? (Context.Instance.BaseStyle.focusable ?? throw new NoNullAllowedException());
-            set => focusable = value;
-        }
-
-        /// <summary>
-        /// Enabled
-        /// </summary>
-
-        bool? enabled;
-
-        bool? _Enabled
-        {
-            get
-            {
-                if (enabled != null) return enabled;
-
-                foreach (Style style in Parents)
-                {
-                    bool? val = style._Enabled;
-
-                    if (val != null) return val;
-                }
-
-                return null;
-            }
-        }
-
-        public bool Enabled
-        {
-            get => _Enabled ?? (Context.Instance.BaseStyle.enabled ?? throw new NoNullAllowedException());
-            set => enabled = value;
-        }
-
-        /// <summary>
         /// Corner Radius
         /// </summary>
 
@@ -241,35 +183,6 @@ namespace Ngco
         {
             get => _CornerRadius ?? (Context.Instance.BaseStyle.cornerRadius ?? throw new NoNullAllowedException());
             set => cornerRadius = value;
-        }
-
-        /// <summary>
-        /// Multiline
-        /// </summary>
-
-        bool? multiline;
-
-        bool? _Multiline
-        {
-            get
-            {
-                if (multiline != null) return multiline;
-
-                foreach (Style style in Parents)
-                {
-                    bool? val = style._Multiline;
-
-                    if (val != null) return val;
-                }
-
-                return null;
-            }
-        }
-
-        public bool Multiline
-        {
-            get => _Multiline ?? (Context.Instance.BaseStyle.multiline ?? throw new NoNullAllowedException());
-            set => multiline = value;
         }
 
         /// <summary>

--- a/Ngco/Widgets/Button.cs
+++ b/Ngco/Widgets/Button.cs
@@ -27,7 +27,12 @@ namespace Ngco.Widgets
 
         public override IEnumerator<BaseWidget> GetEnumerator() => new List<BaseWidget> { Label }.GetEnumerator();
 
-        public Button(BaseWidget label = null) => Label = label;
+        public Button(BaseWidget label = null)
+        {
+            Label = label;
+
+            Focusable = true;
+        }
 
         public override void Load(YamlNode propertiesNode)
         {

--- a/Ngco/Widgets/Button.cs
+++ b/Ngco/Widgets/Button.cs
@@ -58,59 +58,59 @@ namespace Ngco.Widgets
             }
         }
 
-        public override void Measure(Size region)
+        public override void OnMeasure(Size region)
         {
-            Label.Measure(new Size(region.Width  - (Style.Layout.Padding.Left + Style.Layout.Padding.Right),
-                                   region.Height - (Style.Layout.Padding.Up   + Style.Layout.Padding.Down)));
+            Label.OnMeasure(new Size(region.Width  - (Layout.Padding.Left + Layout.Padding.Right),
+                                   region.Height - (Layout.Padding.Up   + Layout.Padding.Down)));
 
-            BoundingBox = new Rect(new Point(0, 0), new Size(Label.BoundingBox.Size.Width  + Style.Layout.Padding.Left + Style.Layout.Padding.Right,
-                                                             Label.BoundingBox.Size.Height + Style.Layout.Padding.Up   + Style.Layout.Padding.Down));
+            BoundingBox = new Rect(new Point(0, 0), new Size(Label.BoundingBox.Size.Width  + Layout.Padding.Left + Layout.Padding.Right,
+                                                             Label.BoundingBox.Size.Height + Layout.Padding.Up   + Layout.Padding.Down));
 
             ApplyLayoutSize();
         }
 
-        public override void Layout(Rect region)
+        public override void OnLayout(Rect region)
         {
             Point labelPosition = new Point();
 
-            switch (Label.Style.Layout.ContentAlignment.HorizontalAlignment)
+            switch (Label.Layout.ContentAlignment.HorizontalAlignment)
             {
                 case HorizontalAlignment.Left:
-                    labelPosition.X += Style.Layout.Padding.Left;
+                    labelPosition.X += Layout.Padding.Left;
                     break;
 
                 case HorizontalAlignment.Center:
-                    int availableWidth    = region.Size.Width - (Style.Layout.Padding.Left + Style.Layout.Padding.Right);
+                    int availableWidth    = region.Size.Width - (Layout.Padding.Left + Layout.Padding.Right);
                     int availableWidthMid = availableWidth / 2;
                     int labelMidX         = Label.BoundingBox.Size.Width / 2;
 
                     // Center label
-                    labelPosition.X += Style.Layout.Padding.Left + availableWidthMid - labelMidX;
+                    labelPosition.X += Layout.Padding.Left + availableWidthMid - labelMidX;
                     break;
 
                 case HorizontalAlignment.Right:
-                    labelPosition.X = region.Size.Width - Style.Layout.Padding.Right - Label.BoundingBox.Size.Width;
+                    labelPosition.X = region.Size.Width - Layout.Padding.Right - Label.BoundingBox.Size.Width;
                     break;
             }
 
-            switch (Label.Style.Layout.ContentAlignment.VerticalAlignment)
+            switch (Label.Layout.ContentAlignment.VerticalAlignment)
             {
                 case VerticalAlignment.Up:
-                    labelPosition.Y += Style.Layout.Padding.Up;
+                    labelPosition.Y += Layout.Padding.Up;
                     break;
 
                 case VerticalAlignment.Center:
-                    int availableHeight    = region.Size.Height - (Style.Layout.Padding.Up + Style.Layout.Padding.Down);
+                    int availableHeight    = region.Size.Height - (Layout.Padding.Up + Layout.Padding.Down);
                     int availableHeightMid = availableHeight / 2;
                     int labelMidY          = Label.BoundingBox.Size.Height / 2;
 
                     // Center label
-                    labelPosition.Y += Style.Layout.Padding.Up + availableHeightMid - labelMidY;
+                    labelPosition.Y += Layout.Padding.Up + availableHeightMid - labelMidY;
 
                     break;
 
                 case VerticalAlignment.Down:
-                    labelPosition.Y = region.Size.Height - Style.Layout.Padding.Down - Label.BoundingBox.Size.Height;
+                    labelPosition.Y = region.Size.Height - Layout.Padding.Down - Label.BoundingBox.Size.Height;
                     break;
 
                 case VerticalAlignment.Stretch:
@@ -120,7 +120,7 @@ namespace Ngco.Widgets
 
             Label.SetPosition(region.TopLeft + labelPosition);
             Label.BoundingBox.ClipTo(region);
-            Label.Layout(Label.BoundingBox);
+            Label.OnLayout(Label.BoundingBox);
         }
 
         public override void Render(RICanvas canvas)

--- a/Ngco/Widgets/Button.cs
+++ b/Ngco/Widgets/Button.cs
@@ -1,6 +1,9 @@
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using YamlDotNet.RepresentationModel;
 
 namespace Ngco.Widgets
 {
@@ -25,6 +28,31 @@ namespace Ngco.Widgets
         public override IEnumerator<BaseWidget> GetEnumerator() => new List<BaseWidget> { Label }.GetEnumerator();
 
         public Button(BaseWidget label = null) => Label = label;
+
+        public override void Load(YamlNode propertiesNode)
+        {
+            var properties = (YamlSequenceNode)propertiesNode;
+            for (int index = 0; index < properties.Children.Count; index++)
+            {
+                var    sub                  = properties.Children[index];
+                var    (keyNode, valueNode) = ((YamlMappingNode)sub).Children.First();
+                string key                  = keyNode.ToString().ToLower();
+
+                string value = valueNode.ToString();
+
+                switch (key)
+                {
+                    case "label":
+                        var label = ((YamlSequenceNode)valueNode).Children.First();
+                        Label     = new Label(label.ToString());
+                        break;
+                    default:
+                        continue;
+                }
+
+                ((YamlSequenceNode)propertiesNode).Children.Remove(sub);
+            }
+        }
 
         public override void Measure(Size region)
         {

--- a/Ngco/Widgets/Button.cs
+++ b/Ngco/Widgets/Button.cs
@@ -11,6 +11,8 @@ namespace Ngco.Widgets
     {
         BaseWidget _Label;
 
+        public override string[] PropertyKeys { get; } = new string[] { "label" };
+
         public BaseWidget Label
         {
             get => _Label;
@@ -34,27 +36,11 @@ namespace Ngco.Widgets
             Focusable = true;
         }
 
-        public override void Load(YamlNode propertiesNode)
+        public override void Load(Dictionary<string, string> properties)
         {
-            var properties = (YamlSequenceNode)propertiesNode;
-            for (int index = 0; index < properties.Children.Count; index++)
+            if (properties.TryGetValue("label", out string imagePath))
             {
-                var    sub                  = properties.Children[index];
-                var    (keyNode, valueNode) = ((YamlMappingNode)sub).Children.First();
-                string key                  = keyNode.ToString().ToLower();
-
-                string value = valueNode.ToString();
-
-                switch (key)
-                {
-                    case "label":
-                        Label = new Label(valueNode.ToString());
-                        break;
-                    default:
-                        continue;
-                }
-
-                ((YamlSequenceNode)propertiesNode).Children.Remove(sub);
+                Label = new Label(imagePath);
             }
         }
 

--- a/Ngco/Widgets/Button.cs
+++ b/Ngco/Widgets/Button.cs
@@ -43,8 +43,7 @@ namespace Ngco.Widgets
                 switch (key)
                 {
                     case "label":
-                        var label = ((YamlSequenceNode)valueNode).Children.First();
-                        Label     = new Label(label.ToString());
+                        Label = new Label(valueNode.ToString());
                         break;
                     default:
                         continue;

--- a/Ngco/Widgets/HBox.cs
+++ b/Ngco/Widgets/HBox.cs
@@ -8,7 +8,7 @@ namespace Ngco.Widgets
         public int HPadding = 10;
         public int VPadding = 10;
 
-        public override void Measure(Size region)
+        public override void OnMeasure(Size region)
         {
             Size rowSize     = new Size(region.Width, region.Height / Children.Count);
             Rect bb          = new Rect(new Point(), new Size());
@@ -18,7 +18,7 @@ namespace Ngco.Widgets
             {
                 BaseWidget widget = Children[i];
 
-                widget.Measure(rowSize);
+                widget.OnMeasure(rowSize);
 
                 if (i == 0)
                 {
@@ -28,12 +28,12 @@ namespace Ngco.Widgets
                 else
                 {
                     contentSize.Height = Math.Max(contentSize.Height, widget.BoundingBox.Size.Height);
-                    contentSize.Width  = contentSize.Width + widget.BoundingBox.Size.Width + Style.Layout.Spacing;
+                    contentSize.Width  = contentSize.Width + widget.BoundingBox.Size.Width + Layout.Spacing;
                 }
             }
 
-            Size paddedSize = new Size(contentSize.Width  + Style.Layout.Padding.Left + Style.Layout.Padding.Right,
-                                       contentSize.Height + Style.Layout.Padding.Up   + Style.Layout.Padding.Down);
+            Size paddedSize = new Size(contentSize.Width  + Layout.Padding.Left + Layout.Padding.Right,
+                                       contentSize.Height + Layout.Padding.Up   + Layout.Padding.Down);
 
             BoundingBox = bb;
 
@@ -41,7 +41,7 @@ namespace Ngco.Widgets
             ApplyLayoutSize();
         }
 
-        public override void Layout(Rect region)
+        public override void OnLayout(Rect region)
         {
             Point currentWidgetPosition = region.TopLeft;
             int   columnHeight          = region.Size.Height;
@@ -53,11 +53,11 @@ namespace Ngco.Widgets
 
                 if (i == 0)
                 {
-                    currentWidgetPosition.X += Style.Layout.Padding.Left;
-                    currentWidgetPosition.Y += Style.Layout.Padding.Up;
+                    currentWidgetPosition.X += Layout.Padding.Left;
+                    currentWidgetPosition.Y += Layout.Padding.Up;
                 }
 
-                int paddingOffset = -Style.Layout.Padding.Down;
+                int paddingOffset = -Layout.Padding.Down;
                 int midY          = widgetPosition.Y + (int)Math.Ceiling((float)columnHeight / 2);
 
                 // Reposition widget
@@ -68,12 +68,12 @@ namespace Ngco.Widgets
                 // Apply offset
                 widgetPosition.Y        += paddingOffset;
                 widgetPosition           = widgetPosition + currentWidgetPosition;
-                currentWidgetPosition.X += widget.BoundingBox.Size.Width + Style.Layout.Spacing;
+                currentWidgetPosition.X += widget.BoundingBox.Size.Width + Layout.Spacing;
 
                 // Update position
                 widget.SetPosition(widgetPosition);
                 widget.BoundingBox.ClipTo(region);
-                widget.Layout(widget.BoundingBox);
+                widget.OnLayout(widget.BoundingBox);
             }
         }
 

--- a/Ngco/Widgets/Image.cs
+++ b/Ngco/Widgets/Image.cs
@@ -33,21 +33,19 @@ namespace Ngco.Widgets
             var properties = (YamlSequenceNode)propertiesNode;
             for (int index = 0; index < properties.Children.Count; index++)
             {
-                var sub = properties.Children[index];
-                if (sub is YamlScalarNode scalar)
-                    Path = scalar.Value;
-                else
+                var    sub                  = properties.Children[index];
+                var    (keyNode, valueNode) = ((YamlMappingNode)sub).Children.First();
+                string key                  = keyNode.ToString().ToLower();
+
+                string value = valueNode.ToString();
+
+                switch (key)
                 {
-                    var    (keyNode, valueNode) = ((YamlMappingNode)sub).Children.First();
-                    string key                  = keyNode.ToString().ToLower();
-
-                    string value = valueNode.ToString();
-
-                    switch (key)
-                    {
-                        default:
-                            continue;
-                    }
+                    case "path":
+                        Path = valueNode.ToString();
+                        break;
+                    default:
+                        continue;
                 }
 
                 ((YamlSequenceNode)propertiesNode).Children.Remove(sub);
@@ -56,6 +54,8 @@ namespace Ngco.Widgets
 
         private void LoadImage()
         {
+            ImageLoaded?.Dispose();
+
             if (_Path != "" && File.Exists(_Path))
             {
                 using (FileStream stream = new FileStream(_Path, FileMode.Open))

--- a/Ngco/Widgets/Image.cs
+++ b/Ngco/Widgets/Image.cs
@@ -76,13 +76,13 @@ namespace Ngco.Widgets
             }
         }
 
-        public override void Measure(Size region)
+        public override void OnMeasure(Size region)
         {
             BoundingBox = _Path != "" && File.Exists(_Path) ? new Rect(new Point(), new Size(ImageLoaded.Width, ImageLoaded.Height)) : new Rect();
 
             ApplyLayoutSize();
         }
 
-        public override void Layout(Rect region) {}
+        public override void OnLayout(Rect region) {}
     }
 }

--- a/Ngco/Widgets/Image.cs
+++ b/Ngco/Widgets/Image.cs
@@ -1,5 +1,6 @@
 ﻿using SkiaSharp;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using YamlDotNet.RepresentationModel;
@@ -9,6 +10,8 @@ namespace Ngco.Widgets
     public class Image : BaseWidget
     {
         private SKBitmap ImageLoaded;
+
+        public override string[] PropertyKeys { get; } = new string[] { "path" }; 
 
         string _Path;
 
@@ -28,27 +31,11 @@ namespace Ngco.Widgets
             LoadImage();
         }
 
-        public override void Load(YamlNode propertiesNode)
+        public override void Load(Dictionary<string, string> properties)
         {
-            var properties = (YamlSequenceNode)propertiesNode;
-            for (int index = 0; index < properties.Children.Count; index++)
+            if(properties.TryGetValue("path", out string imagePath))
             {
-                var    sub                  = properties.Children[index];
-                var    (keyNode, valueNode) = ((YamlMappingNode)sub).Children.First();
-                string key                  = keyNode.ToString().ToLower();
-
-                string value = valueNode.ToString();
-
-                switch (key)
-                {
-                    case "path":
-                        Path = valueNode.ToString();
-                        break;
-                    default:
-                        continue;
-                }
-
-                ((YamlSequenceNode)propertiesNode).Children.Remove(sub);
+                Path = imagePath;
             }
         }
 

--- a/Ngco/Widgets/Image.cs
+++ b/Ngco/Widgets/Image.cs
@@ -1,6 +1,8 @@
 ﻿using SkiaSharp;
 using System;
 using System.IO;
+using System.Linq;
+using YamlDotNet.RepresentationModel;
 
 namespace Ngco.Widgets
 {
@@ -24,6 +26,32 @@ namespace Ngco.Widgets
         {
             _Path = path;
             LoadImage();
+        }
+
+        public override void Load(YamlNode propertiesNode)
+        {
+            var properties = (YamlSequenceNode)propertiesNode;
+            for (int index = 0; index < properties.Children.Count; index++)
+            {
+                var sub = properties.Children[index];
+                if (sub is YamlScalarNode scalar)
+                    Path = scalar.Value;
+                else
+                {
+                    var    (keyNode, valueNode) = ((YamlMappingNode)sub).Children.First();
+                    string key                  = keyNode.ToString().ToLower();
+
+                    string value = valueNode.ToString();
+
+                    switch (key)
+                    {
+                        default:
+                            continue;
+                    }
+                }
+
+                ((YamlSequenceNode)propertiesNode).Children.Remove(sub);
+            }
         }
 
         private void LoadImage()

--- a/Ngco/Widgets/Label.cs
+++ b/Ngco/Widgets/Label.cs
@@ -3,6 +3,8 @@ using System;
 using System.Linq;
 using YamlDotNet.RepresentationModel;
 
+using static Ngco.Parsers;
+
 namespace Ngco.Widgets
 {
     public class Label : BaseWidget
@@ -11,11 +13,19 @@ namespace Ngco.Widgets
 
         SKPaint Paint => new SKPaint
         {
-            Color       = Style.TextColor,
+            Color = Style.TextColor,
             IsAntialias = true,
-            TextSize    = Style.TextSize,
-            Typeface    = SKTypeface.FromFamilyName(Style.FontFamily ?? "Arial")
+            TextSize = Style.TextSize,
+            Typeface = SKTypeface.FromFamilyName(Style.FontFamily ?? "Arial")
         };
+
+        private bool _multiline = false;
+
+        public bool Multiline
+        {
+            get => _multiline;
+            set => _multiline = value;
+        }
 
         public Label(string text = "Label") => Text = text;
 
@@ -24,9 +34,9 @@ namespace Ngco.Widgets
             var properties = (YamlSequenceNode)propertiesNode;
             for (int index = 0; index < properties.Children.Count; index++)
             {
-                var    sub                  = properties.Children[index];
-                var    (keyNode, valueNode) = ((YamlMappingNode)sub).Children.First();
-                string key                  = keyNode.ToString().ToLower();
+                var sub = properties.Children[index];
+                var (keyNode, valueNode) = ((YamlMappingNode)sub).Children.First();
+                string key = keyNode.ToString().ToLower();
 
                 string value = valueNode.ToString();
 
@@ -34,6 +44,9 @@ namespace Ngco.Widgets
                 {
                     case "label":
                         Text = valueNode.ToString();
+                        break;
+                    case "multiline":
+                        Multiline = ParseBool(valueNode.ToString());
                         break;
                     default:
                         continue;
@@ -45,7 +58,7 @@ namespace Ngco.Widgets
 
         public override void Measure(Size region)
         {
-            string[] lines = Style.Multiline ? Text.Split("\n", StringSplitOptions.RemoveEmptyEntries) : new string[] { Text };
+            string[] lines = Multiline ? Text.Split("\n", StringSplitOptions.RemoveEmptyEntries) : new string[] { Text };
 
             BoundingBox = new Rect(new Point(), new Size((int)Math.Ceiling(Paint.MeasureText(lines.OrderByDescending(s => s.Length).First())),
                                                          Style.TextSize * lines.Length));
@@ -59,10 +72,10 @@ namespace Ngco.Widgets
 
             canvas.Save();
             canvas.ClipRect(BoundingBox.Inset(BoundingBox.Size * -0.1f));
-            canvas.DrawText(Text, BoundingBox.TopLeft.X, BoundingBox.TopLeft.Y - (paint.FontSpacing - Style.TextSize) + Style.TextSize, paint, Style.Multiline);
+            canvas.DrawText(Text, BoundingBox.TopLeft.X, BoundingBox.TopLeft.Y - (paint.FontSpacing - Style.TextSize) + Style.TextSize, paint, Multiline);
             canvas.Restore();
         }
 
-        public override void Layout(Rect region) {}
+        public override void Layout(Rect region) { }
     }
 }

--- a/Ngco/Widgets/Label.cs
+++ b/Ngco/Widgets/Label.cs
@@ -24,21 +24,19 @@ namespace Ngco.Widgets
             var properties = (YamlSequenceNode)propertiesNode;
             for (int index = 0; index < properties.Children.Count; index++)
             {
-                var sub = properties.Children[index];
-                if (sub is YamlScalarNode scalar)
-                    Text = scalar.Value;
-                else
+                var    sub                  = properties.Children[index];
+                var    (keyNode, valueNode) = ((YamlMappingNode)sub).Children.First();
+                string key                  = keyNode.ToString().ToLower();
+
+                string value = valueNode.ToString();
+
+                switch (key)
                 {
-                    var    (keyNode, valueNode) = ((YamlMappingNode)sub).Children.First();
-                    string key                  = keyNode.ToString().ToLower();
-
-                    string value = valueNode.ToString();
-
-                    switch (key)
-                    {
-                        default:
-                            continue;
-                    }
+                    case "label":
+                        Text = valueNode.ToString();
+                        break;
+                    default:
+                        continue;
                 }
 
                 ((YamlSequenceNode)propertiesNode).Children.Remove(sub);
@@ -47,7 +45,7 @@ namespace Ngco.Widgets
 
         public override void Measure(Size region)
         {
-            string[] lines = Style.Multiline ? Text.Split("\\n") : new string[] { Text };
+            string[] lines = Style.Multiline ? Text.Split("\n", StringSplitOptions.RemoveEmptyEntries) : new string[] { Text };
 
             BoundingBox = new Rect(new Point(), new Size((int)Math.Ceiling(Paint.MeasureText(lines.OrderByDescending(s => s.Length).First())),
                                                          Style.TextSize * lines.Length));

--- a/Ngco/Widgets/Label.cs
+++ b/Ngco/Widgets/Label.cs
@@ -12,7 +12,7 @@ namespace Ngco.Widgets
     {
         public string Text;
 
-        public override string[] PropertyKeys { get; } = new string[] { "label", "multiline" };
+        public override string[] PropertyKeys { get; } = new string[] { "text", "multiline" };
 
         SKPaint Paint => new SKPaint
         {
@@ -34,7 +34,7 @@ namespace Ngco.Widgets
 
         public override void Load(Dictionary<string, string> properties)
         {
-            if (properties.TryGetValue("label", out string imagePath))
+            if (properties.TryGetValue("text", out string imagePath))
             {
                 Text = imagePath;
             }

--- a/Ngco/Widgets/Label.cs
+++ b/Ngco/Widgets/Label.cs
@@ -1,9 +1,10 @@
 using SkiaSharp;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using YamlDotNet.RepresentationModel;
 
-using static Ngco.Parsers;
+using static Ngco.Helpers;
 
 namespace Ngco.Widgets
 {
@@ -11,12 +12,14 @@ namespace Ngco.Widgets
     {
         public string Text;
 
+        public override string[] PropertyKeys { get; } = new string[] { "label", "multiline" };
+
         SKPaint Paint => new SKPaint
         {
-            Color = Style.TextColor,
+            Color       = Style.TextColor,
             IsAntialias = true,
-            TextSize = Style.TextSize,
-            Typeface = SKTypeface.FromFamilyName(Style.FontFamily ?? "Arial")
+            TextSize    = Style.TextSize,
+            Typeface    = SKTypeface.FromFamilyName(Style.FontFamily ?? "Arial")
         };
 
         private bool _multiline = false;
@@ -29,30 +32,16 @@ namespace Ngco.Widgets
 
         public Label(string text = "Label") => Text = text;
 
-        public override void Load(YamlNode propertiesNode)
+        public override void Load(Dictionary<string, string> properties)
         {
-            var properties = (YamlSequenceNode)propertiesNode;
-            for (int index = 0; index < properties.Children.Count; index++)
+            if (properties.TryGetValue("label", out string imagePath))
             {
-                var sub = properties.Children[index];
-                var (keyNode, valueNode) = ((YamlMappingNode)sub).Children.First();
-                string key = keyNode.ToString().ToLower();
+                Text = imagePath;
+            }
 
-                string value = valueNode.ToString();
-
-                switch (key)
-                {
-                    case "label":
-                        Text = valueNode.ToString();
-                        break;
-                    case "multiline":
-                        Multiline = ParseBool(valueNode.ToString());
-                        break;
-                    default:
-                        continue;
-                }
-
-                ((YamlSequenceNode)propertiesNode).Children.Remove(sub);
+            if (properties.TryGetValue("multiline", out string isMultiline))
+            {
+                Multiline = ParseBool(isMultiline);
             }
         }
 

--- a/Ngco/Widgets/Label.cs
+++ b/Ngco/Widgets/Label.cs
@@ -56,7 +56,7 @@ namespace Ngco.Widgets
             }
         }
 
-        public override void Measure(Size region)
+        public override void OnMeasure(Size region)
         {
             string[] lines = Multiline ? Text.Split("\n", StringSplitOptions.RemoveEmptyEntries) : new string[] { Text };
 
@@ -76,6 +76,6 @@ namespace Ngco.Widgets
             canvas.Restore();
         }
 
-        public override void Layout(Rect region) { }
+        public override void OnLayout(Rect region) { }
     }
 }

--- a/Ngco/Widgets/Label.cs
+++ b/Ngco/Widgets/Label.cs
@@ -1,6 +1,7 @@
 using SkiaSharp;
 using System;
 using System.Linq;
+using YamlDotNet.RepresentationModel;
 
 namespace Ngco.Widgets
 {
@@ -17,6 +18,32 @@ namespace Ngco.Widgets
         };
 
         public Label(string text = "Label") => Text = text;
+
+        public override void Load(YamlNode propertiesNode)
+        {
+            var properties = (YamlSequenceNode)propertiesNode;
+            for (int index = 0; index < properties.Children.Count; index++)
+            {
+                var sub = properties.Children[index];
+                if (sub is YamlScalarNode scalar)
+                    Text = scalar.Value;
+                else
+                {
+                    var    (keyNode, valueNode) = ((YamlMappingNode)sub).Children.First();
+                    string key                  = keyNode.ToString().ToLower();
+
+                    string value = valueNode.ToString();
+
+                    switch (key)
+                    {
+                        default:
+                            continue;
+                    }
+                }
+
+                ((YamlSequenceNode)propertiesNode).Children.Remove(sub);
+            }
+        }
 
         public override void Measure(Size region)
         {

--- a/Ngco/Widgets/TextBox.cs
+++ b/Ngco/Widgets/TextBox.cs
@@ -24,7 +24,12 @@ namespace Ngco.Widgets
 
         public override bool IsFocusable => true;
 
-        public TextBox(BaseWidget label = null) => Label = label;
+        public TextBox(BaseWidget label = null)
+        {
+            Label = label;
+
+            Focusable = true;
+        }
 
         public override void Load(YamlNode propertiesNode)
         {

--- a/Ngco/Widgets/TextBox.cs
+++ b/Ngco/Widgets/TextBox.cs
@@ -10,7 +10,7 @@ namespace Ngco.Widgets
     {
         BaseWidget _Label;
 
-        public override string[] PropertyKeys { get; } = new string[] { "label" };
+        public override string[] PropertyKeys { get; } = new string[] { "text" };
 
         public BaseWidget Label
         {
@@ -35,7 +35,7 @@ namespace Ngco.Widgets
 
         public override void Load(Dictionary<string, string> properties)
         {
-            if (properties.TryGetValue("label", out string imagePath))
+            if (properties.TryGetValue("text", out string imagePath))
             {
                 Label = new Label(imagePath);
             }

--- a/Ngco/Widgets/TextBox.cs
+++ b/Ngco/Widgets/TextBox.cs
@@ -136,27 +136,27 @@ namespace Ngco.Widgets
             return this;
         }
 
-        public override void Measure(Size region)
+        public override void OnMeasure(Size region)
         {
-            Label.Measure(new Size(region.Width  - (Style.Layout.Padding.Left + Style.Layout.Padding.Right),
-                                   region.Height - (Style.Layout.Padding.Up   + Style.Layout.Padding.Down)));
+            Label.OnMeasure(new Size(region.Width  - (Layout.Padding.Left + Layout.Padding.Right),
+                                   region.Height - (Layout.Padding.Up   + Layout.Padding.Down)));
 
-            BoundingBox = new Rect(new Point(0, 0), new Size(Label.BoundingBox.Size.Width  + Style.Layout.Padding.Left + Style.Layout.Padding.Right,
-                                                             Label.BoundingBox.Size.Height + Style.Layout.Padding.Up   + Style.Layout.Padding.Down));
+            BoundingBox = new Rect(new Point(0, 0), new Size(Label.BoundingBox.Size.Width  + Layout.Padding.Left + Layout.Padding.Right,
+                                                             Label.BoundingBox.Size.Height + Layout.Padding.Up   + Layout.Padding.Down));
 
             ApplyLayoutSize();
         }
 
-        public override void Layout(Rect region)
+        public override void OnLayout(Rect region)
         {
             Point labelPosition = new Point();
 
-            labelPosition.X += Style.Layout.Padding.Left;
-            labelPosition.Y += Style.Layout.Padding.Up;
+            labelPosition.X += Layout.Padding.Left;
+            labelPosition.Y += Layout.Padding.Up;
 
             Label.SetPosition(region.TopLeft + labelPosition);
             Label.BoundingBox.ClipTo(region);
-            Label.Layout(Label.BoundingBox);
+            Label.OnLayout(Label.BoundingBox);
         }
     }
 }

--- a/Ngco/Widgets/TextBox.cs
+++ b/Ngco/Widgets/TextBox.cs
@@ -10,6 +10,8 @@ namespace Ngco.Widgets
     {
         BaseWidget _Label;
 
+        public override string[] PropertyKeys { get; } = new string[] { "label" };
+
         public BaseWidget Label
         {
             get => _Label;
@@ -31,27 +33,11 @@ namespace Ngco.Widgets
             Focusable = true;
         }
 
-        public override void Load(YamlNode propertiesNode)
+        public override void Load(Dictionary<string, string> properties)
         {
-            var properties = (YamlSequenceNode)propertiesNode;
-            for (int index = 0; index < properties.Children.Count; index++)
+            if (properties.TryGetValue("label", out string imagePath))
             {
-                var    sub                  = properties.Children[index];
-                var    (keyNode, valueNode) = ((YamlMappingNode)sub).Children.First();
-                string key                  = keyNode.ToString().ToLower();
-
-                string value = valueNode.ToString();
-
-                switch (key)
-                {
-                    case "label":
-                        Label = new Label(valueNode.ToString());
-                        break;
-                    default:
-                        continue;
-                }
-
-                ((YamlSequenceNode)propertiesNode).Children.Remove(sub);
+                Label = new Label(imagePath);
             }
         }
 

--- a/Ngco/Widgets/TextBox.cs
+++ b/Ngco/Widgets/TextBox.cs
@@ -40,8 +40,7 @@ namespace Ngco.Widgets
                 switch (key)
                 {
                     case "label":
-                        var label = ((YamlSequenceNode)valueNode).Children.First();
-                        Label     = new Label(label.ToString());
+                        Label = new Label(valueNode.ToString());
                         break;
                     default:
                         continue;

--- a/Ngco/Widgets/TextBox.cs
+++ b/Ngco/Widgets/TextBox.cs
@@ -1,6 +1,8 @@
 ﻿using SkiaSharp;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using YamlDotNet.RepresentationModel;
 
 namespace Ngco.Widgets
 {
@@ -23,6 +25,31 @@ namespace Ngco.Widgets
         public override bool IsFocusable => true;
 
         public TextBox(BaseWidget label = null) => Label = label;
+
+        public override void Load(YamlNode propertiesNode)
+        {
+            var properties = (YamlSequenceNode)propertiesNode;
+            for (int index = 0; index < properties.Children.Count; index++)
+            {
+                var    sub                  = properties.Children[index];
+                var    (keyNode, valueNode) = ((YamlMappingNode)sub).Children.First();
+                string key                  = keyNode.ToString().ToLower();
+
+                string value = valueNode.ToString();
+
+                switch (key)
+                {
+                    case "label":
+                        var label = ((YamlSequenceNode)valueNode).Children.First();
+                        Label     = new Label(label.ToString());
+                        break;
+                    default:
+                        continue;
+                }
+
+                ((YamlSequenceNode)propertiesNode).Children.Remove(sub);
+            }
+        }
 
         public override IEnumerator<BaseWidget> GetEnumerator() => new List<BaseWidget> { Label }.GetEnumerator();
 

--- a/Ngco/Widgets/VBox.cs
+++ b/Ngco/Widgets/VBox.cs
@@ -8,7 +8,7 @@ namespace Ngco.Widgets
         public int HPadding = 10;
         public int VPadding = 10;
 
-        public override void Measure(Size region)
+        public override void OnMeasure(Size region)
         {
             Size rowSize     = new Size(region.Width, region.Height / Children.Count);
             Rect bb          = new Rect(new Point(), new Size());
@@ -17,7 +17,7 @@ namespace Ngco.Widgets
             for (int i = 0; i < Children.Count; i++)
             {
                 BaseWidget widget = Children[i];
-                widget.Measure(rowSize);
+                widget.OnMeasure(rowSize);
 
                 if (i == 0)
                 {
@@ -27,12 +27,12 @@ namespace Ngco.Widgets
                 else
                 {
                     contentSize.Width  = Math.Max(contentSize.Width, widget.BoundingBox.Size.Width);
-                    contentSize.Height = contentSize.Height + widget.BoundingBox.Size.Height + Style.Layout.Spacing;
+                    contentSize.Height = contentSize.Height + widget.BoundingBox.Size.Height + Layout.Spacing;
                 }
             }
 
-            Size paddedSize = new Size(contentSize.Width  + Style.Layout.Padding.Left + Style.Layout.Padding.Right,
-                                       contentSize.Height + Style.Layout.Padding.Up   + Style.Layout.Padding.Down);
+            Size paddedSize = new Size(contentSize.Width  + Layout.Padding.Left + Layout.Padding.Right,
+                                       contentSize.Height + Layout.Padding.Up   + Layout.Padding.Down);
 
             BoundingBox = bb;
 
@@ -40,7 +40,7 @@ namespace Ngco.Widgets
             ApplyLayoutSize();
         }
 
-        public override void Layout(Rect region)
+        public override void OnLayout(Rect region)
         {
             Point currentWidgetPosition = region.TopLeft;
             int   rowWidth              = region.Size.Width;
@@ -52,11 +52,11 @@ namespace Ngco.Widgets
 
                 if (i == 0)
                 {
-                    currentWidgetPosition.X += Style.Layout.Padding.Left;
-                    currentWidgetPosition.Y += Style.Layout.Padding.Up;
+                    currentWidgetPosition.X += Layout.Padding.Left;
+                    currentWidgetPosition.Y += Layout.Padding.Up;
                 }
 
-                int paddingOffset = -Style.Layout.Padding.Right;
+                int paddingOffset = -Layout.Padding.Right;
                 int midX          = widgetPosition.X + (int)Math.Ceiling((float)rowWidth / 2);
 
                 // Reposition widget
@@ -67,12 +67,12 @@ namespace Ngco.Widgets
                 // Apply offset
                 widgetPosition.X        += paddingOffset;
                 widgetPosition           = widgetPosition + currentWidgetPosition;
-                currentWidgetPosition.Y += widget.BoundingBox.Size.Height + Style.Layout.Spacing;
+                currentWidgetPosition.Y += widget.BoundingBox.Size.Height + Layout.Spacing;
                 
                 // Update position
                 widget.SetPosition(widgetPosition);
                 widget.BoundingBox.ClipTo(region);
-                widget.Layout(widget.BoundingBox);
+                widget.OnLayout(widget.BoundingBox);
             }
         }
 

--- a/TestApp/layout.yml
+++ b/TestApp/layout.yml
@@ -6,8 +6,6 @@ styles:
       text-color: white
       text-size: 30
       font-family: Arial
-      focusable: false
-      enabled: true
       multiline: false
       corner-radius: 0
       layout: 
@@ -28,7 +26,6 @@ styles:
       text-color: rgb(109, 109, 109)
       multiline: true
   - button:
-      focusable: true
       background-color: rgb(225, 225, 225)
   - "button :hover":
       background-color: rgb(180, 213, 230)
@@ -41,7 +38,6 @@ styles:
   - textbox:
       background-color: white
       outline-color: blue
-      focusable: true
       text-color: black
       layout:
         width: 400

--- a/TestApp/layout.yml
+++ b/TestApp/layout.yml
@@ -51,45 +51,42 @@ styles:
 widgets:
   - vbox:
     - label:
-      - Testing Labels!
+        - label: Testing Labels!
     - label:
-      - Some more testing
+        - label: Some more testing
     - textbox:
-        - label:
-            - Please edit this text...
+        - label: Please edit this text...
     - hbox:
       - image:
-        - cat.png
+        - path: .\cat.png
       - vbox:
-        - label:
-          - CAT
-          - class: header
-        - label:
-          - The cat (Felis catus, or Felis silvestris catus, literally "woodland cat"),\noften referred to as the domestic cat to distinguish from other felids\nand felines, is a small, typically furry, carnivorous mammal.
-          - class: desc
+        - label: 
+            - label: CAT
+            - class: header
+        - label: 
+            - label : |
+                The cat (Felis catus, or Felis silvestris catus, literally "woodland cat"),
+                often referred to as the domestic cat to distinguish from other felids
+                and felines, is a small, typically furry, carnivorous mammal.
+            - class: desc
     - button:
-      - id: button-a
-      - class: testing foo
-      - label:
-        - Button A
+        - id: button-a
+        - class: testing foo
+        - label: Button A
     - button:
         - id: button-b
         - class: radius
-        - label:
-            - Button B
+        - label: Button B
     - hbox:
         - button:
-            - label:
-                - Foo
+            - label: Foo
         - button:
-            - label:
-                - Bar
+            - label: Bar
         - button:
-            - label:
-                - Baz
+            - label:  Baz
     - hbox:
         - label:
-            - And even more
+            - label: And even more
             - class: testing
-        - label:
-            - Aaaaand more
+        - label: 
+            - label: Aaaaand more

--- a/TestApp/layout.yml
+++ b/TestApp/layout.yml
@@ -35,20 +35,20 @@ styles:
 widgets:
   - vbox:
     - label:
-        - label: Testing Labels!
+        - text: Testing Labels!
     - label:
-        - label: Some more testing
+        - text: Some more testing
     - textbox:
-        - label: Please edit this text...
+        - text: Please edit this text...
     - hbox:
       - image:
         - path: .\cat.png
       - vbox:
         - label: 
-            - label: CAT
+            - text: CAT
             - class: header
         - label: 
-            - label : |
+            - text : |
                 The cat (Felis catus, or Felis silvestris catus, literally "woodland cat"),
                 often referred to as the domestic cat to distinguish from other felids
                 and felines, is a small, typically furry, carnivorous mammal.
@@ -71,7 +71,7 @@ widgets:
             - label:  Baz
     - hbox:
         - label:
-            - label: And even more
+            - text: And even more
             - class: testing
         - label: 
-            - label: Aaaaand more
+            - text: Aaaaand more

--- a/TestApp/layout.yml
+++ b/TestApp/layout.yml
@@ -6,16 +6,7 @@ styles:
       text-color: white
       text-size: 30
       font-family: Arial
-      multiline: false
       corner-radius: 0
-      layout: 
-        width: 0
-        height: 0
-        vertical-alignment: stretch
-        horizontal-alignment: stretch
-        margin: 5
-        padding: 5
-        spacing: 5
   - hbox > .testing:
       text-color: green
       text-size: 75
@@ -24,7 +15,6 @@ styles:
       text-size: 75
   - label .desc:
       text-color: rgb(109, 109, 109)
-      multiline: true
   - button:
       background-color: rgb(225, 225, 225)
   - "button :hover":
@@ -39,8 +29,6 @@ styles:
       background-color: white
       outline-color: blue
       text-color: black
-      layout:
-        width: 400
   - "textbox :focused":
       outline-color: red
 
@@ -65,6 +53,7 @@ widgets:
                 often referred to as the domestic cat to distinguish from other felids
                 and felines, is a small, typically furry, carnivorous mammal.
             - class: desc
+            - multiline: true
     - button:
         - id: button-a
         - class: testing foo


### PR DESCRIPTION
This adds support for custom widget properties. Widgets now load their custom or unique properties, instead of relying on the loader. Thus we can extend the current properties with properties specific to certain widgets without adding a case for them in style or the widget loader.
Also moves focusable, enabled, layout and multiline to properties instead of keeping it in styles.